### PR TITLE
add caching db to proxy service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ __pycache__
 *.json
 *.log
 evaluation/deberta_runs/
+
+.idea

--- a/pipeline/core/service_manager.py
+++ b/pipeline/core/service_manager.py
@@ -3,46 +3,106 @@ import subprocess
 import time
 import sys
 import os
+import urllib.request
+import urllib.error
+
+# Must match the path in pubmed_proxy.py
+SHARED_DIR = "/data/home/jak38842/disk/fact_checker/pubmed_db_cache"
+
+def wait_for_health(port, timeout=15):
+    """Polls the health endpoint until it responds 200 OK."""
+    start_time = time.time()
+    health_url = f"http://127.0.0.1:{port}/health"
+
+    print(f"     Waiting for service to be healthy at {health_url}...")
+
+    while time.time() - start_time < timeout:
+        try:
+            with urllib.request.urlopen(health_url, timeout=1) as response:
+                if response.status == 200:
+                    print("     Service is healthy!")
+                    return True
+        except (urllib.error.URLError, ConnectionResetError):
+            pass
+        except Exception as e:
+            # Ignore other startup glitches
+            pass
+
+        time.sleep(0.5)
+
+    return False
+
+
+def check_process_alive(proc):
+    """Returns False if process has exited."""
+    if proc.poll() is not None:
+        return False
+    return True
 
 
 def ensure_pubmed_proxy(port=8080):
-    """Checks if the proxy is running; if not, starts it as a background process."""
+    """Checks if the proxy is running; if not, starts it and waits for health."""
+
+    # 1. Quick Socket Check (Is anything listening?)
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        is_running = s.connect_ex(('127.0.0.1', port)) == 0
+        is_port_open = s.connect_ex(('127.0.0.1', port)) == 0
 
-    if not is_running:
-        print(f"--- Starting Shared PubMed Proxy Service on port {port} ---")
-
-        # 1. Determine the absolute path to the proxy script
-        # We assume this file is in: pipeline/core/service_manager.py
-        # We want to find:          services/pubmed_proxy.py
-
-        current_dir = os.path.dirname(os.path.abspath(__file__))  # .../pipeline/core
-        pipeline_dir = os.path.dirname(current_dir)  # .../pipeline
-        project_root = os.path.dirname(pipeline_dir)  # .../ (Root)
-
-        script_path = os.path.join(project_root, "services", "pubmed_proxy.py")
-
-        # 2. Verify the file exists before trying to run it
-        if not os.path.exists(script_path):
-            print(f"[ERROR] Service Manager could not find: {script_path}")
-            print(f"        Please check that 'pubmed_proxy.py' is in the 'services' folder at the project root.")
+    if is_port_open:
+        # It's open, but is it our proxy? Quick health check to be sure.
+        if wait_for_health(port, timeout=2):
             return
+        print("     [WARNING] Port is open but service is not responding correctly.")
 
-        # 3. Setup logging
-        log_path = os.path.join(project_root, "pubmed_proxy.log")
-        log_file = open(log_path, "a")
+    print(f"--- Starting Shared PubMed Proxy Service on port {port} ---")
 
-        # 4. Launch
-        subprocess.Popen(
-            [sys.executable, script_path],
-            stdout=log_file,
-            stderr=log_file,
-            start_new_session=True  # Detach the process
-        )
+    # 2. Locate script
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    pipeline_dir = os.path.dirname(current_dir)
+    project_root = os.path.dirname(pipeline_dir)
+    script_path = os.path.join(project_root, "services", "pubmed_proxy.py")
 
-        # Wait a moment for it to boot
-        time.sleep(2)
+    if not os.path.exists(script_path):
+        print(f"[ERROR] Cannot find proxy script at: {script_path}")
+        return
+
+    # 3. Prepare Shared Directory
+    if not os.path.exists(SHARED_DIR):
+        try:
+            os.makedirs(SHARED_DIR, mode=0o777, exist_ok=True)
+            os.chmod(SHARED_DIR, 0o777)
+        except Exception:
+            pass
+
+    log_path = os.path.join(SHARED_DIR, "pubmed_proxy.log")
+    log_file = open(log_path, "a")
+
+    # 4. Launch Process
+    proc = subprocess.Popen(
+        [sys.executable, script_path],
+        stdout=log_file,
+        stderr=log_file,
+        start_new_session=True
+    )
+
+    # 5. Robust Wait
+    if wait_for_health(port, timeout=15):
+        return
+
+    # 6. Handle Failure
+    print(f"[ERROR] Service failed to start within 15 seconds.")
+
+    # Check if process died immediately
+    if not check_process_alive(proc):
+        print("        Process exited unexpectedly. Checking last 5 log lines:")
+        try:
+            with open(log_path, "r") as f:
+                lines = f.readlines()[-5:]
+                for line in lines:
+                    print(f"        LOG: {line.strip()}")
+        except Exception:
+            print("        (Could not read log file)")
     else:
-        # Service is already running
-        pass
+        print("        Process is running but not responsive. Killing it.")
+        proc.kill()
+
+    sys.exit(1)

--- a/services/pubmed_proxy.py
+++ b/services/pubmed_proxy.py
@@ -2,27 +2,83 @@ import asyncio
 import time
 import os
 import signal
+import sqlite3
+import hashlib
+import json
 import httpx
 from contextlib import asynccontextmanager
 from fastapi import FastAPI, Response, Request
 from aiolimiter import AsyncLimiter
 import uvicorn
 
-# SAFETY CONFIG:
-# We limit to 3 requests every 1.5 seconds to account for network bursts.
+# --- CONFIGURATION ---
+# Use a shared system path so all clones use the SAME cache file
+SHARED_DIR = "/data/home/jak38842/disk/fact_checker/pubmed_db_cache"
+DB_FILE = os.path.join(SHARED_DIR, "pubmed_cache.db")
+
+IDLE_TIMEOUT = 300  # 5 minutes
 limiter = AsyncLimiter(3, 1.5)
 
 last_request_time = time.time()
-IDLE_TIMEOUT = 600  # 5 minutes
 NCBI_BASE = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
 
-# SIMPLE IN-MEMORY CACHE
-# Key: (util_name, sorted_params_tuple) | Value: (content, status, media_type)
-PROXY_CACHE = {}
+
+def ensure_shared_dir():
+    """Ensure the shared directory exists and is writable by all."""
+    if not os.path.exists(SHARED_DIR):
+        try:
+            os.makedirs(SHARED_DIR, mode=0o777, exist_ok=True)
+            os.chmod(SHARED_DIR, 0o777)
+        except Exception as e:
+            print(f"Warning creating shared dir: {e}")
+
+
+def init_db():
+    """Create the cache table and ensure file permissions."""
+    ensure_shared_dir()
+
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute("""
+                     CREATE TABLE IF NOT EXISTS cache
+                     (
+                         key
+                         TEXT
+                         PRIMARY
+                         KEY,
+                         content
+                         BLOB,
+                         status
+                         INTEGER,
+                         media_type
+                         TEXT,
+                         created_at
+                         REAL
+                     )
+                     """)
+        conn.commit()
+
+    try:
+        os.chmod(DB_FILE, 0o666)
+    except Exception:
+        pass
+
+
+def get_cache(key: str):
+    with sqlite3.connect(DB_FILE) as conn:
+        cur = conn.execute("SELECT content, status, media_type FROM cache WHERE key = ?", (key,))
+        return cur.fetchone()
+
+
+def set_cache(key: str, content: bytes, status: int, media_type: str):
+    with sqlite3.connect(DB_FILE) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO cache (key, content, status, media_type, created_at) VALUES (?, ?, ?, ?, ?)",
+            (key, content, status, media_type, time.time())
+        )
+        conn.commit()
 
 
 async def monitor_idle():
-    """Background task to shut down the service if no one is using it."""
     while True:
         await asyncio.sleep(10)
         if time.time() - last_request_time > IDLE_TIMEOUT:
@@ -32,7 +88,9 @@ async def monitor_idle():
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    print("Initializing PubMed Proxy (Safe Mode + Caching)...")
+    print(f"Initializing Shared PubMed Proxy...")
+    print(f"DATABASE: {DB_FILE}")
+    init_db()
     monitor_task = asyncio.create_task(monitor_idle())
     yield
     print("Shutting down PubMed Proxy...")
@@ -42,57 +100,59 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="PubMed Shared Proxy", lifespan=lifespan)
 
 
+def generate_key(util: str, params: dict) -> str:
+    serialized = json.dumps(dict(sorted(params.items())))
+    raw_key = f"{util}|{serialized}"
+    return hashlib.md5(raw_key.encode()).hexdigest()
+
+
+@app.get("/health")
+def health_check():
+    """Simple health check endpoint."""
+    return {"status": "running"}
+
+
 @app.get("/proxy/{util}")
 async def proxy_pubmed(util: str, request: Request):
     global last_request_time
     last_request_time = time.time()
 
-    target_url = f"{NCBI_BASE}/{util}"
-    # Convert query params to a sorted tuple so it can be used as a dictionary key
-    # (Sorting ensures 'a=1&b=2' hits the same cache as 'b=2&a=1')
     params = dict(request.query_params)
-    cache_key = (util, tuple(sorted(params.items())))
+    cache_key = generate_key(util, params)
 
-    # 1. CHECK CACHE (Fast Path)
-    if cache_key in PROXY_CACHE:
-        # Debug print to show it's working
-        print(f"CACHE HIT: {util} (Params: {len(params)})")
-        content, status, media = PROXY_CACHE[cache_key]
+    # 1. CHECK DISK CACHE
+    cached = get_cache(cache_key)
+    if cached:
+        content, status, media = cached
+        print(f"DISK HIT: {util}")
         return Response(content=content, status_code=status, media_type=media)
 
-    # 2. FETCH FROM UPSTREAM (Slow Path)
+    # 2. FETCH FROM UPSTREAM
+    target_url = f"{NCBI_BASE}/{util}"
     async with httpx.AsyncClient() as client:
         for attempt in range(3):
-            # Only use the rate limiter for actual network calls
             async with limiter:
                 try:
                     resp = await client.get(target_url, params=params)
-
                     if resp.status_code == 429:
                         wait_time = 2 * (attempt + 1)
-                        print(f"NCBI 429 Rate Limit hit. Retrying in {wait_time}s...")
+                        print(f"NCBI 429 Rate Limit. Retry in {wait_time}s...")
                         await asyncio.sleep(wait_time)
                         continue
 
-                    # 3. SAVE TO CACHE (If successful)
                     if resp.status_code == 200:
-                        PROXY_CACHE[cache_key] = (
-                            resp.content,
-                            resp.status_code,
-                            resp.headers.get("content-type")
-                        )
+                        set_cache(cache_key, resp.content, resp.status_code, resp.headers.get("content-type"))
 
                     return Response(
                         content=resp.content,
                         status_code=resp.status_code,
                         media_type=resp.headers.get("content-type")
                     )
-
                 except httpx.RequestError as e:
                     print(f"Request Error: {e}")
                     return Response(content=str(e), status_code=502)
 
-    return Response(content="NCBI Rate Limit Exceeded (Retries failed)", status_code=429)
+    return Response(content="NCBI Rate Limit Exceeded", status_code=429)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request significantly improves the reliability and scalability of the PubMed proxy service by replacing the in-memory cache with a shared SQLite-based disk cache, adding robust health checks, and enhancing service startup and monitoring logic. These changes ensure that all users and clones on the same machine share a single cache, improve service startup diagnostics, and provide a consistent mechanism for health checking.

**PubMed Proxy Service Enhancements:**

* Replaced the in-memory cache with a SQLite-based disk cache stored in a shared directory (`pubmed_cache.db`), allowing all service instances and clones on the same machine to share cached results. This includes new helper functions for initializing the database and reading/writing cache entries. [[1]](diffhunk://#diff-da6ce99bc76c6e8216525f760017aa9632326e0c608f4155a5b899703c13287cR5-L25) [[2]](diffhunk://#diff-da6ce99bc76c6e8216525f760017aa9632326e0c608f4155a5b899703c13287cR103-R155)
* Added a `/health` endpoint to the FastAPI app for robust health checking and service monitoring.
* Improved cache key generation using a deterministic hash of the utility name and sorted parameters to ensure consistent cache lookups.
* Ensured the shared directory and database file are created with permissions that allow access from all users.

**Service Startup and Monitoring Improvements:**

* Updated `ensure_pubmed_proxy` in `service_manager.py` to perform a robust health check after starting the proxy, handle process startup failures more gracefully, and provide clearer error reporting and log output on failure.
* The proxy service now logs to the shared directory, and the idle timeout mechanism is slightly adjusted for reliability. [[1]](diffhunk://#diff-da6ce99bc76c6e8216525f760017aa9632326e0c608f4155a5b899703c13287cR5-L25) [[2]](diffhunk://#diff-da6ce99bc76c6e8216525f760017aa9632326e0c608f4155a5b899703c13287cL35-R93)