### PR TITLE
Modularize PubMed query prompts, add counter-query variants, separate PubMed/RAG evidence, and increase retmax

### DIFF
--- a/pipeline/steps/verification.py
+++ b/pipeline/steps/verification.py
@@ -189,17 +189,26 @@ class TruthnessStep(PipelineStep):
         for stmt in state.statements:
             stmt.evidence.sort(key=lambda ev: float(getattr(ev, "relevance", 0.0) or 0.0))
             # 1. Build Evidence Block
-            evidence_lines = []
+            pubmed_lines = []
             rag_lines = []
             for ev in stmt.evidence:
                 if _source_type_value(ev) == SourceType.RAG.value:
                     rag_lines.append(_format_rag_chunk(ev, include_text=True))
                 else:
-                    evidence_lines.append(_format_evidence_line(ev, include_text=True))
+                    pubmed_lines.append(_format_evidence_line(ev, include_text=True))
 
-            evidence_block = "\n".join(evidence_lines) or "No evidence provided."
-
+            pubmed_block = "\n".join(pubmed_lines) or "No PubMed evidence provided."
             rag_block = "\n".join(rag_lines) or "No RAG chunks provided."
+
+            evidence_block = "\n".join(
+                [
+                    "PUBMED EVIDENCE:",
+                    pubmed_block,
+                    "",
+                    "RAG EVIDENCE:",
+                    rag_block,
+                ]
+            ).strip()
 
             # 2. Call LLM
             try:

--- a/pipeline/test_configs/kai_test.py
+++ b/pipeline/test_configs/kai_test.py
@@ -1,4 +1,14 @@
-from pipeline.test_configs.preprompts import PROMPT_TMPL_S2, PROMPT_TMPL_S3_BALANCED, PROMPT_TMPL_S3_SPECIFIC, PROMPT_TMPL_S3_ATM_ASSISTED, PROMPT_TMPL_S6, PROMPT_TMPL_S7
+from pipeline.test_configs.preprompts import (
+    PROMPT_TMPL_S2,
+    PROMPT_TMPL_S3_BALANCED,
+    PROMPT_TMPL_S3_BALANCED_COUNTER,
+    PROMPT_TMPL_S3_SPECIFIC,
+    PROMPT_TMPL_S3_SPECIFIC_COUNTER,
+    PROMPT_TMPL_S3_ATM_ASSISTED,
+    PROMPT_TMPL_S3_ATM_ASSISTED_COUNTER,
+    PROMPT_TMPL_S6,
+    PROMPT_TMPL_S7,
+)
 
 BASE_TEMPERATURE = 0.3
 
@@ -16,6 +26,14 @@ RESEARCH_MODULE = {
                     "temperature": BASE_TEMPERATURE,
                 }
             },
+            {
+                "type": "generate_query",  # Step 3
+                "settings": {
+                    "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_BALANCED_COUNTER,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
         {
                 "type": "generate_query",  # Step 3
                 "settings": {
@@ -28,13 +46,29 @@ RESEARCH_MODULE = {
                 "type": "generate_query",  # Step 3
                 "settings": {
                     "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_SPECIFIC_COUNTER,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
+        {
+                "type": "generate_query",  # Step 3
+                "settings": {
+                    "model": "gemma3:27b",
                     "prompt_template": PROMPT_TMPL_S3_ATM_ASSISTED,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
+        {
+                "type": "generate_query",  # Step 3
+                "settings": {
+                    "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_ATM_ASSISTED_COUNTER,
                     "temperature": BASE_TEMPERATURE,
                 }
             },
             {
                 "type": "fetch_links",  # Step 4
-                "settings": {"retmax": 10}
+                "settings": {"retmax": 20}
             },
             {
                 "type": "summarize_evidence",  # Step 5


### PR DESCRIPTION
### Motivation
- Reduce duplication across the six Step 3 PubMed query prompt templates by factoring shared text into reusable building blocks. 
- Add dedicated counter-evidence query templates to prioritize retrieving null/negative or harm-related findings. 
- Make the truth-scoring LLM input explicitly show PubMed vs RAG evidence so each source type is visible and labeled. 
- Improve evidence retrieval coverage by increasing `fetch_links` `retmax` from `10` to `20`.

### Description
- Refactored `pipeline/test_configs/preprompts.py` to introduce modular components (`S3_INTRO`, `S3_OUTPUT_RULES_*`, `S3_SEMANTIC_RULES_*`) and rebuilt the six `PROMPT_TMPL_S3_*` templates (including `_COUNTER` variants) using `_s3_prompt` helpers. 
- Updated `pipeline/test_configs/kai_test.py` to import the new counter templates, insert corresponding `generate_query` steps for each counter prompt, and set the `fetch_links` `retmax` to `20`. 
- Modified `TruthnessStep.execute` in `pipeline/steps/verification.py` to separate `pubmed_lines` and `rag_lines`, produce `pubmed_block` and `rag_block`, assemble a labeled `evidence_block` containing both `PUBMED EVIDENCE:` and `RAG EVIDENCE:`, and continue passing `rag_chunks=rag_block` to the prompt. 
- Small escaping/formatting fixes to ensure prompts are valid Python strings and maintain previous sorting/parsing behavior.

### Testing
- Ran a Python syntax check via `ast.parse` on `pipeline/test_configs/preprompts.py`, which succeeded (`OK`).
- No automated unit or integration tests were executed for this change.

------
