### PR TITLE
feature/counter-evidence

### DIFF
--- a/pipeline/steps/verification.py
+++ b/pipeline/steps/verification.py
@@ -189,17 +189,34 @@ class TruthnessStep(PipelineStep):
         for stmt in state.statements:
             stmt.evidence.sort(key=lambda ev: float(getattr(ev, "relevance", 0.0) or 0.0))
             # 1. Build Evidence Block
-            evidence_lines = []
+            pubmed_lines = []
+            epistemonikos_lines = []  # TODO: confirm Epistemonikos formatting expectations for this list
             rag_lines = []
             for ev in stmt.evidence:
-                if _source_type_value(ev) == SourceType.RAG.value:
+                source_type = _source_type_value(ev)
+                if source_type == SourceType.RAG.value:
                     rag_lines.append(_format_rag_chunk(ev, include_text=True))
+                elif source_type == SourceType.EPISTEMONIKOS.value:
+                    epistemonikos_lines.append(_format_evidence_line(ev, include_text=True))
                 else:
-                    evidence_lines.append(_format_evidence_line(ev, include_text=True))
+                    pubmed_lines.append(_format_evidence_line(ev, include_text=True))
 
-            evidence_block = "\n".join(evidence_lines) or "No evidence provided."
+            pubmed_block = "\n".join(pubmed_lines) or "No PubMed evidence provided."
+            epistemonikos_block = "\n".join(epistemonikos_lines) or "No Epistemonikos evidence provided."
+            rag_block = "\n".join(rag_lines) or "No RAG evidence provided."
 
-            rag_block = "\n".join(rag_lines) or "No RAG chunks provided."
+            evidence_block = "\n".join(
+                [
+                    "PUBMED EVIDENCE:",
+                    pubmed_block,
+                    "",
+                    "EPISTEMONIKOS EVIDENCE:",
+                    epistemonikos_block,
+                    "",
+                    "RAG EVIDENCE:",
+                    rag_block,
+                ]
+            )
 
             # 2. Call LLM
             try:

--- a/pipeline/test_configs/kai_test.py
+++ b/pipeline/test_configs/kai_test.py
@@ -1,4 +1,14 @@
-from pipeline.test_configs.preprompts import PROMPT_TMPL_S2, PROMPT_TMPL_S3_BALANCED, PROMPT_TMPL_S3_SPECIFIC, PROMPT_TMPL_S3_ATM_ASSISTED, PROMPT_TMPL_S6, PROMPT_TMPL_S7
+from pipeline.test_configs.preprompts import (
+    PROMPT_TMPL_S2,
+    PROMPT_TMPL_S3_BALANCED,
+    PROMPT_TMPL_S3_SPECIFIC,
+    PROMPT_TMPL_S3_ATM_ASSISTED,
+    PROMPT_TMPL_S3_BALANCED_COUNTER,
+    PROMPT_TMPL_S3_SPECIFIC_COUNTER,
+    PROMPT_TMPL_S3_ATM_ASSISTED_COUNTER,
+    PROMPT_TMPL_S6,
+    PROMPT_TMPL_S7,
+)
 
 BASE_TEMPERATURE = 0.3
 
@@ -24,7 +34,7 @@ RESEARCH_MODULE = {
                     "temperature": BASE_TEMPERATURE,
                 }
             },
-        {
+            {
                 "type": "generate_query",  # Step 3
                 "settings": {
                     "model": "gemma3:27b",
@@ -33,8 +43,32 @@ RESEARCH_MODULE = {
                 }
             },
             {
+                "type": "generate_query",  # Step 3 (counter-evidence)
+                "settings": {
+                    "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_BALANCED_COUNTER,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
+            {
+                "type": "generate_query",  # Step 3 (counter-evidence)
+                "settings": {
+                    "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_SPECIFIC_COUNTER,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
+            {
+                "type": "generate_query",  # Step 3 (counter-evidence)
+                "settings": {
+                    "model": "gemma3:27b",
+                    "prompt_template": PROMPT_TMPL_S3_ATM_ASSISTED_COUNTER,
+                    "temperature": BASE_TEMPERATURE,
+                }
+            },
+            {
                 "type": "fetch_links",  # Step 4
-                "settings": {"retmax": 10}
+                "settings": {"retmax": 20}
             },
             {
                 "type": "summarize_evidence",  # Step 5


### PR DESCRIPTION
This pull request introduces several improvements to the evidence handling and query generation pipeline for biomedical fact-checking. The main changes include grouping evidence by source type for clearer presentation, expanding the test configuration to include counter-evidence query generation steps, and adding new prompt templates specifically designed for counter-evidence queries. These updates enhance both the clarity of evidence output and the ability to search for studies that refute or challenge claims.

**Evidence grouping and formatting:**

* Evidence blocks in `pipeline/steps/verification.py` are now grouped and labeled by source type: PubMed, Epistemonikos, and RAG, improving clarity in evidence presentation.
* The evidence prompt in `pipeline/test_configs/preprompts.py` was updated to reflect grouped evidence, further clarifying how evidence is presented in prompts.

**Counter-evidence query generation:**

* The test configuration in `pipeline/test_configs/kai_test.py` was expanded to add three new pipeline steps for generating PubMed queries that focus on counter-evidence, using newly introduced prompt templates.
* The import statement in `pipeline/test_configs/kai_test.py` was updated to include the new counter-evidence prompt templates.

**Prompt templates for counter-evidence:**

* Three new prompt templates were added to `pipeline/test_configs/preprompts.py` for generating PubMed queries that prioritize counter-evidence, each with detailed instructions for different query strategies (balanced, specific, ATM-assisted).